### PR TITLE
Distinguish between outputs and variables

### DIFF
--- a/cloudbuild-task-azp/src/Outputs.ts
+++ b/cloudbuild-task-azp/src/Outputs.ts
@@ -5,4 +5,8 @@ export class Outputs implements contracts.Outputs {
 	setVariable(name: string, value: string): void {
 		task.setVariable(name, value);
 	}
+
+	setOutput(name: string, value: string): void {
+		task.debug(`Output variable ${name} not set to "${value}" because Azure Pipelines does not support output variables.`);
+	}
 }

--- a/cloudbuild-task-contracts/src/Outputs.ts
+++ b/cloudbuild-task-contracts/src/Outputs.ts
@@ -1,7 +1,15 @@
 export interface Outputs {
-	/** Sets a variable that will impact this and subsequent tasks.
-	 * @param name The name of the variable
+	/**
+	 * Sets a variable that will impact this and subsequent tasks, generally by setting a persistent environment variable.
+	 * @param name The name of the (environment) variable.
 	 * @param value The value of the variable.
 	 */
 	setVariable(name: string, value: string): void;
+
+	/**
+	 * Sets an output variable that the workflow/pipeline can directly consume if they wire a symbol up to receive it.
+	 * @param name The name of the output variable.
+	 * @param value The value of the output variable.
+	 */
+	setOutput(name: string, value: string): void;
 }

--- a/cloudbuild-task-github-actions/src/Outputs.ts
+++ b/cloudbuild-task-github-actions/src/Outputs.ts
@@ -3,6 +3,10 @@ import * as core from '@actions/core';
 
 export class Outputs implements contracts.Outputs {
 	setVariable(name: string, value: string): void {
+		core.exportVariable(name, value);
+	}
+
+	setOutput(name: string, value: string): void {
 		core.setOutput(name, value);
 	}
 }

--- a/cloudbuild-task-local/src/Outputs.ts
+++ b/cloudbuild-task-local/src/Outputs.ts
@@ -5,11 +5,19 @@ export class Outputs implements contracts.Outputs {
 	/** The variables that have been set. */
 	public readonly variables: { [key: string]: string } = {};
 
+	/** The outputs that have been set. */
+	public readonly outputs: { [key: string]: string } = {};
+
 	constructor(private readonly log: Logger) {
 	}
 
 	setVariable(name: string, value: string): void {
 		this.log.debug(`Variable set: ${name}=${value}`);
 		this.variables[name] = value;
+	}
+
+	setOutput(name: string, value: string): void {
+		this.log.debug(`Output set: ${name}=${value}`);
+		this.outputs[name] = value;
 	}
 }


### PR DESCRIPTION
GitHub has action *outputs* (which are wired up to symbols explicitly by the invoker) as well as setting variables which effectively become env vars for the rest of the build.
Azure Pipelines only has the latter. It has no task outputs.

But the two concepts were conflated before now, with the one API we offered leading AzP to set a variable and GitHub to set a task output.
Now we have one API that sets variables in both, and a set output API that only works in GitHub (and no-ops in AzP).

Fixes #8