### PR TITLE
Remove Outputs.setOutput method

### DIFF
--- a/cloudbuild-task-azp/src/Outputs.ts
+++ b/cloudbuild-task-azp/src/Outputs.ts
@@ -5,8 +5,4 @@ export class Outputs implements contracts.Outputs {
 	setVariable(name: string, value: string): void {
 		task.setVariable(name, value);
 	}
-
-	setOutput(name: string, value: string): void {
-		task.debug(`Output variable ${name} not set to "${value}" because Azure Pipelines does not support output variables.`);
-	}
 }

--- a/cloudbuild-task-contracts/src/Outputs.ts
+++ b/cloudbuild-task-contracts/src/Outputs.ts
@@ -5,11 +5,4 @@ export interface Outputs {
 	 * @param value The value of the variable.
 	 */
 	setVariable(name: string, value: string): void;
-
-	/**
-	 * Sets an output variable that the workflow/pipeline can directly consume if they wire a symbol up to receive it.
-	 * @param name The name of the output variable.
-	 * @param value The value of the output variable.
-	 */
-	setOutput(name: string, value: string): void;
 }

--- a/cloudbuild-task-github-actions/src/Outputs.ts
+++ b/cloudbuild-task-github-actions/src/Outputs.ts
@@ -5,8 +5,4 @@ export class Outputs implements contracts.Outputs {
 	setVariable(name: string, value: string): void {
 		core.exportVariable(name, value);
 	}
-
-	setOutput(name: string, value: string): void {
-		core.setOutput(name, value);
-	}
 }

--- a/cloudbuild-task-local/src/Outputs.ts
+++ b/cloudbuild-task-local/src/Outputs.ts
@@ -5,19 +5,11 @@ export class Outputs implements contracts.Outputs {
 	/** The variables that have been set. */
 	public readonly variables: { [key: string]: string } = {};
 
-	/** The outputs that have been set. */
-	public readonly outputs: { [key: string]: string } = {};
-
 	constructor(private readonly log: Logger) {
 	}
 
 	setVariable(name: string, value: string): void {
 		this.log.debug(`Variable set: ${name}=${value}`);
 		this.variables[name] = value;
-	}
-
-	setOutput(name: string, value: string): void {
-		this.log.debug(`Output set: ${name}=${value}`);
-		this.outputs[name] = value;
 	}
 }


### PR DESCRIPTION
This is only supported by GitHub Actions. Until a second CI system that supports it exists, we shouldn't include it in the abstraction.