### PR TITLE
Update documentation and use proper PR ID for GitHub PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ To configure *your* VS Code IDE's language service to work in this repo, complet
 
 1. Open any .ts file in this repo.
 1. Press Ctrl+Shift+P
-1. Choose "Select TypeScript Version"
+1. Choose "Typescript: Select TypeScript Version"
 1. Pick "Use Workspace Version"
 
 Another caveat to not using `node_modules` is that F12 Go to Definition on imported types cannot jump to imported modules.

--- a/cloudbuild-task-azp/src/index.ts
+++ b/cloudbuild-task-azp/src/index.ts
@@ -25,11 +25,11 @@ class AzurePipelinesFactory implements contracts.CloudTask {
 
 	constructor() {
 		if (task.getVariable('Build.Reason') === 'PullRequest') {
-			const pullRequestId = task.getVariable('System.PullRequest.PullRequestId');
 			const pullRequestNumber = task.getVariable('System.PullRequest.PullRequestNumber');
+			const pullRequestId = task.getVariable('System.PullRequest.PullRequestId');
 			const id: number | undefined =
-				pullRequestId ? Number.parseInt(pullRequestId, 10) :
-					pullRequestNumber ? Number.parseInt(pullRequestNumber, 10) :
+				pullRequestNumber ? Number.parseInt(pullRequestNumber, 10) :
+					pullRequestId ? Number.parseInt(pullRequestId, 10) :
 						undefined;
 
 			if (id === undefined) {


### PR DESCRIPTION
For [this PR](https://github.com/vsls-contrib/pomodoro/pull/11), the Azure Pipelines build sets the value `System.PullRequest.PullRequestNumber=11`, but `System.PullRequest.PullRequestId=373407960`. Clearly, we want to set the id to be 11 and not 373407960.

I've tested this change on PRs for source hosted on both GitHub and AzureDevOps.
