### PR TITLE
Add Source Commit Id for ADO PRs

### DIFF
--- a/cloudbuild-task-azp/src/index.ts
+++ b/cloudbuild-task-azp/src/index.ts
@@ -40,7 +40,7 @@ class AzurePipelinesFactory implements contracts.CloudTask {
 				id: id,
 				sourceBranch: {
 					ref: task.getVariable('System.PullRequest.SourceBranch')!,
-					sha: undefined, // No documented way to look this up.
+					sha: task.getVariable('System.PullRequest.SourceCommitId')!,
 				},
 				targetBranch: {
 					ref: task.getVariable('System.PullRequest.TargetBranch')!,


### PR DESCRIPTION
Code Index is running into a bug since we don't have the commit id currently, this change populates that field.

While the variable is not listed in [official docs ](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml), there's an [open issue to add it](https://github.com/MicrosoftDocs/azure-devops-docs/issues/4588) and was [confirmed to be officially supported ](https://github.com/microsoft/azure-pipelines-tasks/issues/9801#issuecomment-504179159).